### PR TITLE
refactor: use multiext and extract basename as param in rule build_database #19

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,8 +19,10 @@ rule build_database:
         "logs/{sample}_build_database.log",
     conda:
         "envs/rmod_database.yaml"
+    params:
+        basename=lambda wildcards: f"results/rmod_database/{wildcards.sample}/{wildcards.sample}_rmod",
     shell:
-        """filename={output[0]}; basename="${{filename%.nhr}}" && BuildDatabase -name ${{basename}} {input.genome} &> {log}"""
+        """BuildDatabase -name {params.basename} {input.genome} &> {log}"""
 
 
 rule run_repeatmodeler2:


### PR DESCRIPTION
## This Pull Request (PR):

use multiext and extract basename as param in rule build_database
solves issue #19 


### Review and tests:
- [x] New code is executed and covered by tests, and test approve
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Check that all tests passes
- [ ] Generate a new DAG-graph if you have added a new rule
- [ ] Update the `requirements.md`
- [x] Update the `Issues` tab
- [ ] Refer to the Issue number in the PR title
<BR>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database build workflow configuration for improved consistency and maintainability in output handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->