### PR TITLE
feat: support multiple genome inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Edit `config/config.yaml` before running.
 #### Required settings
 
 ```yaml
-samples:
-  - "my_genome"   # basename of data/my_genome.fasta.gz
+genomes:
+  - "/path/to/organism1.fasta.gz" # compression suffixes will be stripped to derive sample names
+  - "/path/to/organism2.fna.gz" # fasta suffixes will be stripped to derive sample names
 
 te_name: "Penelope"  # TE family name to find in RepeatModeler output
 ```

--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Edit `config/config.yaml` before running.
 #### Required settings
 
 ```yaml
+# both compression and fasta suffixes will be stripped to derive sample names
 genomes:
-  - "/path/to/organism1.fasta.gz" # compression suffixes will be stripped to derive sample names
-  - "/path/to/organism2.fna.gz" # fasta suffixes will be stripped to derive sample names
+  - "/path/to/organism1.fasta.gz"
+  - "/path/to/organism2.fna.gz"
 
 te_name: "Penelope"  # TE family name to find in RepeatModeler output
 ```

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,7 @@
-samples:
-  - "sample1"
-
 te_name: "Penelope"
 
-genome: "data/sample1.fasta.gz"
+genomes:
+  - "data/sample1.fasta.gz"
 
 repeatmasker:
   engine: "rmblast"

--- a/tests/integration/config/config.yaml
+++ b/tests/integration/config/config.yaml
@@ -1,6 +1,4 @@
-samples:
-  - "genome"
-
 te_name: "Penelope"
 
-genome: "data/genome.fasta.gz"
+genomes:
+  - "data/genome.fasta.gz"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,3 +1,4 @@
+import os
 from snakemake.io import expand, directory, touch, multiext, temp
 
 # Collect PSSM files that will be compiled into the RPS-BLAST database.
@@ -5,12 +6,16 @@ from snakemake.io import expand, directory, touch, multiext, temp
 _PSSM_DIR = config.get("orf_analysis", {}).get("rpsblast", {}).get("pssm_dir", "data/pfam")
 (_SMP_NAMES,) = glob_wildcards(f"{_PSSM_DIR}/{{name}}.smp")
 
+# Derive sample names from genome paths: strip directories and all extensions.
+# e.g. "data/my_genome.fasta.gz" → "my_genome"
+_SAMPLE_TO_GENOME = {os.path.basename(p).split(".")[0]: p for p in config["genomes"]}
+
 
 rule all:
     input:
         expand(
             "results/final/{sample}_{te_name}.done",
-            sample=config["samples"],
+            sample=list(_SAMPLE_TO_GENOME),
             te_name=config["te_name"],
         ),
 
@@ -20,7 +25,7 @@ rule build_database:
     Build a database from the input genome assembly
     """
     input:
-        genome=config["genome"],
+        genome=lambda wildcards: _SAMPLE_TO_GENOME[wildcards.sample],
     output:
         multiext(
             "results/rmod_database/{sample}/{sample}_rmod",

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,7 +8,15 @@ _PSSM_DIR = config.get("orf_analysis", {}).get("rpsblast", {}).get("pssm_dir", "
 
 # Derive sample names from genome paths: strip directories and all extensions.
 # e.g. "data/my_genome.fasta.gz" → "my_genome"
-_SAMPLE_TO_GENOME = {os.path.basename(p).split(".")[0]: p for p in config["genomes"]}
+_SAMPLE_TO_GENOME = {}
+for _p in config["genomes"]:
+    _name = os.path.basename(_p).split(".")[0]
+    if _name in _SAMPLE_TO_GENOME:
+        raise ValueError(
+            f"Duplicate sample name '{_name}' derived from '{_p}' and "
+            f"'{_SAMPLE_TO_GENOME[_name]}'. Rename one of the genome files."
+        )
+    _SAMPLE_TO_GENOME[_name] = _p
 
 
 rule all:
@@ -84,7 +92,7 @@ rule collect_te:
 
 rule repeatmasker:
     input:
-        fasta=config["genome"],
+        fasta=lambda wildcards: _SAMPLE_TO_GENOME[wildcards.sample],
         te_lib="results/collect_te/{sample}/{sample}_{te_name}_family.fa",
     output:
         repeatmasker_dir=directory("results/repeatmasker/{sample}_{te_name}"),
@@ -112,7 +120,7 @@ rule repeatmasker:
 rule plot_repeat_landscape:
     input:
         repeatmasker_dir="results/repeatmasker/{sample}_{te_name}",
-        genome=config["genome"],
+        genome=lambda wildcards: _SAMPLE_TO_GENOME[wildcards.sample],
     output:
         plot="results/plots/{sample}_{te_name}_repeat_landscape.png",
     log:
@@ -140,7 +148,7 @@ rule make_te_bed:
 
 rule decompress_genome:
     input:
-        config["genome"],
+        lambda wildcards: _SAMPLE_TO_GENOME[wildcards.sample],
     output:
         temp("results/genome/{sample}.fasta"),
     shell:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from snakemake.io import expand, directory, touch, multiext, temp
 
 # Collect PSSM files that will be compiled into the RPS-BLAST database.
@@ -6,11 +7,18 @@ from snakemake.io import expand, directory, touch, multiext, temp
 _PSSM_DIR = config.get("orf_analysis", {}).get("rpsblast", {}).get("pssm_dir", "data/pfam")
 (_SMP_NAMES,) = glob_wildcards(f"{_PSSM_DIR}/{{name}}.smp")
 
-# Derive sample names from genome paths: strip directories and all extensions.
-# e.g. "data/my_genome.fasta.gz" → "my_genome"
+# Derive sample names from genome paths: strip known compression and FASTA
+# suffixes so that e.g. "data/E.coli.fasta.gz" → "E.coli".
+_COMPRESSION_SUFFIXES = {".gz", ".bz2", ".xz"}
+_FASTA_SUFFIXES = {".fasta", ".fa", ".fna", ".ffn", ".fas"}
 _SAMPLE_TO_GENOME = {}
 for _p in config["genomes"]:
-    _name = os.path.basename(_p).split(".")[0]
+    _stem = Path(_p).name
+    if Path(_stem).suffix in _COMPRESSION_SUFFIXES:
+        _stem = Path(_stem).stem
+    if Path(_stem).suffix in _FASTA_SUFFIXES:
+        _stem = Path(_stem).stem
+    _name = _stem
     if _name in _SAMPLE_TO_GENOME:
         raise ValueError(
             f"Duplicate sample name '{_name}' derived from '{_p}' and "


### PR DESCRIPTION
## This Pull Request (PR):

Replace the scalar `genome:` key and separate `samples:` list with a single `genomes:` list of paths. Sample names are derived automatically from the filename stem (e.g. `data/my_genome.fasta.gz` → `my_genome`), eliminating the need to maintain a redundant name mapping in config.
Closes issue #48 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration now accepts multiple genome files (a genomes list) instead of a single genome entry.
  * Workflow produces per-sample outputs by deriving sample names from genome file paths and running downstream steps per sample.
  * Validation prevents ambiguous duplicate sample names.

* **Documentation / Tests**
  * README and integration tests updated to reflect the new genomes list format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->