### PR TITLE
feat: add config and input validation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,7 +31,7 @@ orf_analysis:
     # the domain_filter rules below.
     domains_csv: "data/domains.csv"
     # db is built automatically from pssm_dir via the build_rps_database rule
-    evalue: 1e-5
+    evalue: 1.0e-5
     max_target_seqs: 10
     min_query_coverage: 0.35
     min_bitscore: 50

--- a/tests/integration/config/config.yaml
+++ b/tests/integration/config/config.yaml
@@ -2,3 +2,8 @@ te_name: "Penelope"
 
 genomes:
   - "data/genome.fasta.gz"
+
+orf_analysis:
+  rpsblast:
+    pssm_dir: "../../data/pfam"
+    domains_csv: "../../data/domains.csv"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,6 +1,76 @@
 import os
+import csv
 from pathlib import Path
 from snakemake.io import expand, directory, touch, multiext, temp
+from snakemake.utils import validate
+
+# --- Config schema validation (type, range, enum checks) ---
+validate(config, "schemas/config.schema.yaml")
+
+
+def _validate_inputs(cfg):
+    """Check that all referenced files and directories exist and are consistent."""
+    errors = []
+
+    # Genome files must exist
+    for genome_path in cfg.get("genomes", []):
+        if not Path(genome_path).exists():
+            errors.append(f"Genome file not found: '{genome_path}'")
+
+    # PSSM directory and its contents
+    pssm_dir = cfg.get("orf_analysis", {}).get("rpsblast", {}).get("pssm_dir", "data/pfam")
+    smp_files = list(Path(pssm_dir).glob("*.smp")) if Path(pssm_dir).is_dir() else []
+    if not Path(pssm_dir).is_dir():
+        errors.append(f"pssm_dir not found: '{pssm_dir}'")
+    elif not smp_files:
+        errors.append(f"No *.smp files found in pssm_dir: '{pssm_dir}'")
+
+    # domains.csv: exists, two columns, no duplicates, all .smp files present in pssm_dir
+    domains_csv = cfg.get("orf_analysis", {}).get("rpsblast", {}).get("domains_csv", "")
+    if domains_csv:
+        if not Path(domains_csv).exists():
+            errors.append(f"domains_csv not found: '{domains_csv}'")
+        else:
+            seen_smp = {}
+            smp_stems = {f.name for f in smp_files}
+            with open(domains_csv, newline="") as fh:
+                for i, row in enumerate(csv.reader(fh, delimiter="\t"), start=1):
+                    if len(row) != 2:
+                        errors.append(f"domains_csv line {i}: expected 2 tab-separated columns, got {len(row)}")
+                        continue
+                    smp_name, domain_type = row[0].strip(), row[1].strip()
+                    if not domain_type:
+                        errors.append(f"domains_csv line {i}: domain type is empty for '{smp_name}'")
+                    if smp_name in seen_smp:
+                        errors.append(
+                            f"domains_csv line {i}: duplicate entry '{smp_name}' " f"(first seen on line {seen_smp[smp_name]})"
+                        )
+                    seen_smp[smp_name] = i
+                    if smp_stems and smp_name not in smp_stems:
+                        errors.append(f"domains_csv line {i}: '{smp_name}' not found in '{pssm_dir}'")
+
+        # required_domains entries must appear in domains_csv domain types
+        required = cfg.get("orf_analysis", {}).get("domain_filter", {}).get("required_domains", [])
+        if required and Path(domains_csv).exists():
+            known_types = set()
+            with open(domains_csv, newline="") as fh:
+                for row in csv.reader(fh, delimiter="\t"):
+                    if len(row) == 2:
+                        known_types.add(row[1].strip())
+            unknown = [d for d in required if d not in known_types]
+            if unknown:
+                errors.append(
+                    f"required_domains references unknown domain type(s): {unknown}. "
+                    f"Known types from domains_csv: {sorted(known_types)}"
+                )
+
+    if errors:
+        raise ValueError(
+            "Configuration errors found — fix before running the pipeline:\n" + "\n".join(f"  • {e}" for e in errors)
+        )
+
+
+_validate_inputs(config)
 
 # Collect PSSM files that will be compiled into the RPS-BLAST database.
 # Set rpsblast.pssm_dir in config to point to a different directory of *.smp files.

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -1,0 +1,133 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+description: MGERT2 pipeline configuration schema
+type: object
+required:
+  - genomes
+  - te_name
+
+properties:
+  genomes:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      minLength: 1
+    description: "List of genome assembly paths (gzip-compressed FASTA)"
+
+  te_name:
+    type: string
+    minLength: 1
+    description: "TE family name to search for in RepeatModeler output"
+
+  repeatmasker:
+    type: object
+    properties:
+      engine:
+        type: string
+        enum: ["rmblast", "crossmatch", "abblast"]
+      extra:
+        type: string
+    additionalProperties: false
+
+  orf_analysis:
+    type: object
+    properties:
+      min_orf_aa:
+        type: integer
+        minimum: 1
+      require_start_codon:
+        type: boolean
+      max_orfs_per_te:
+        type: integer
+        minimum: 1
+      require_stop_codon:
+        type: boolean
+
+      intrinsic:
+        type: object
+        properties:
+          high_threshold:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+          medium_threshold:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+        additionalProperties: false
+
+      rpsblast:
+        type: object
+        properties:
+          pssm_dir:
+            type: string
+            minLength: 1
+          domains_csv:
+            type: string
+          evalue:
+            type: number
+            minimum: 0.0
+          max_target_seqs:
+            type: integer
+            minimum: 1
+          min_query_coverage:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+          min_bitscore:
+            type: number
+            minimum: 0.0
+        additionalProperties: false
+
+      domain_filter:
+        type: object
+        properties:
+          required_domains:
+            type: array
+            items:
+              type: string
+          min_domain_types_per_orf:
+            type: integer
+            minimum: 1
+          allow_split_across_orfs:
+            type: boolean
+          te_coverage_scope:
+            type: string
+            enum: ["all", "passing"]
+        additionalProperties: false
+
+      classification:
+        type: object
+        properties:
+          high_min_aa:
+            type: integer
+            minimum: 1
+          high_min_intrinsic:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+          putative_min_aa:
+            type: integer
+            minimum: 1
+          putative_min_intrinsic:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+        additionalProperties: false
+
+    additionalProperties: false
+
+  phylogeny:
+    type: object
+    properties:
+      model:
+        type: string
+        minLength: 1
+      bootstrap:
+        type: integer
+        minimum: 100
+      seed:
+        type: integer
+    additionalProperties: false
+
+additionalProperties: false


### PR DESCRIPTION
Closes issue #53 

Add JSON Schema (workflow/schemas/config.schema.yaml) validated via Snakemake's built-in validate() for type, range, and enum checks. Add _validate_inputs() for cross-file checks: genome paths exist, pssm_dir is non-empty, domains_csv has valid structure and no duplicate entries, .smp filenames resolve to actual files, and required_domains values match known domain types. All errors are reported together so users see every problem at once. Fix evalue in config.yaml to 1.0e-5 so YAML parses it as a float rather than a string.

## This Pull Request (PR):

### Review and tests:
- [x] New code is executed and covered by tests, and test approve
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Check that all tests passes
- [x] Generate a new DAG-graph if you have added a new rule
- [x] Update the `requirements.md`
- [x] Update the `Issues` tab
- [x ] Refer to the Issue number in the PR description.
<BR>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration validation now runs at pipeline startup, checking required fields, file/path existence, domain CSV format and consistency, and reporting all issues together.
  * A configuration schema was added to enforce allowed settings and value ranges.

* **Chores**
  * Adjusted an RPS-BLAST e-value parameter formatting.
  * Added an integration test configuration for ORF/domain settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->