### PR TITLE
ci: correct shell expansion in pixi task

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ platforms = ["osx-arm64", "linux-64"]
 [tasks]
 dry-conda = "snakemake -n --cores 1 --use-conda --configfile config/config.yaml"
 full-conda = "snakemake --cores 4 --use-conda --configfile config/config.yaml"
-full-container = { cmd = "snakemake --cores 8 --sdm apptainer --apptainer-prefix ${HOME}/snakemake-apptainer --configfile config/config.yaml", env = { APPTAINER_TMPDIR = "${HOME}/snakemake-apptainer" } }
+full-container = { cmd = "snakemake --cores 8 --sdm apptainer --apptainer-prefix $HOME/snakemake-apptainer --configfile config/config.yaml", env = { APPTAINER_TMPDIR = "$HOME/snakemake-apptainer" } }
 format-smk = "snakefmt -l 130 workflow/Snakefile"
 format-smk-check = "snakefmt --check --verbose -l 130 workflow/Snakefile"
 lint = "snakemake --lint --configfile config/config.yaml"


### PR DESCRIPTION
fix: shell expansion in pixi task 

${HOME} → $HOME in both the cmd and env values. Pixi's shell (deno_task_shell) doesn't support the brace-style ${VAR} expansion — bare $VAR works fine.

## This Pull Request (PR):

### Review and tests:
- [ ] New code is executed and covered by tests, and test approve
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Check that all tests passes
- [ ] Generate a new DAG-graph if you have added a new rule
- [ ] Update the `requirements.md`
- [ ] Update the `Issues` tab
- [ ] Refer to the Issue number in the PR description.
<BR>

